### PR TITLE
Refactor/smaller state

### DIFF
--- a/bm-server-shared/config.js
+++ b/bm-server-shared/config.js
@@ -1,5 +1,5 @@
 export const gridStep = 50
 export const halfStep = 25
-export const mult = 0.65
-export const interval = 10
-export const speed = interval * 0.1
+export const mult = 0.68
+export const interval = 15
+export const gameSpeed =  interval * 0.065

--- a/bm-server/game.js
+++ b/bm-server/game.js
@@ -1,6 +1,6 @@
 import { makeWalls, makeLevelMap, createPlayer } from './initialize.js'
 import { clearTempsState, getNarrowState, state } from '../bm-server-shared/state.js'
-import { interval, speed } from '../bm-server-shared/config.js'
+import { interval } from '../bm-server-shared/config.js'
 import { broadcast, clients, heldInputs, updateCountdown } from '../ws-server.mjs'
 import { startMiniGame } from '../server.mjs'
 
@@ -112,7 +112,7 @@ function runGame() {
             const input = heldInputs.get(p.id)
             if (!input) return // Skip if player disconnected
             if (ending) input.bomb = false     // don't allow bomb drops when end sequence has started
-            p.movePlayer(speed, input)
+            p.movePlayer(input)
             input.bomb = false
         })
 

--- a/bm-server/player.js
+++ b/bm-server/player.js
@@ -23,7 +23,7 @@ export class Player {
         this.bombAmount = 1
         this.bombPower = 2
         this.isMoving = false
-        this.score = 0
+        //this.score = 0
         this.killer = ''
         //this.bombClip = false
         this.wallClip = false
@@ -224,7 +224,7 @@ export class Player {
 
             // power-ups hit
             for (const pow of state.powerups.values()) {
-                if (this.alive && !levelMap[pow.row][pow.col].startsWith('weakWall') && checkHit(playerBounds, pow)) {
+                if (this.alive && (!(levelMap[pow.row][pow.col] && levelMap[pow.row][pow.col].startsWith('weakWall'))) && checkHit(playerBounds, pow)) {
                     if (pow.powerType === 'bomb') {
                         this.bombAmount++
                         this.powerups.push('bombUp')

--- a/bm-server/player.js
+++ b/bm-server/player.js
@@ -2,7 +2,7 @@ import { Bomb } from './bomb.js'
 import { bombTime, bombs, bounds, flames, timedEvents, levelMap, powerUpMap } from './game.js'
 import { Timer } from './timer.js'
 import { state } from '../bm-server-shared/state.js'
-import { gridStep, halfStep, mult } from '../bm-server-shared/config.js'
+import { gameSpeed, gridStep, halfStep, mult } from '../bm-server-shared/config.js'
 import { BombUp, FlameUp, LifeUp, SpeedUp, WallClip } from './powerup.js'
 
 let timedCount = 0
@@ -135,7 +135,7 @@ export class Player {
 
     };
 
-    movePlayer(deltaTime, inputs) {
+    movePlayer(inputs) {
 
         if (this.alive) {
 
@@ -153,7 +153,7 @@ export class Player {
             };
 
             // normalize speed for diagonal movement and different framerates
-            let moveDistance = this.speed * slowDown * deltaTime
+            let moveDistance = this.speed * slowDown * gameSpeed
 
             // calculate next position
             let newX = this.x

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -36,8 +36,22 @@ function replacer(key, value) {
     return value
 }
 
+let stateCount = 0
+
 export function broadcast(obj) {
     const msg = encodeMessage(JSON.stringify(obj, replacer))
+
+    if (obj.type === 'gamestate') {
+        stateCount++
+    }
+
+    if (stateCount % 100 === 0) {
+        console.log(`Broadcasting state ${stateCount} to ${clients.size} clients`)
+        console.log(obj)
+        const sizeInKB = Buffer.byteLength(msg) / 1024
+        console.log(`Message size: ${sizeInKB.toFixed(2)} KB`)
+    }
+
     for (const socket of clients.keys()) {
         try {
             socket.write(msg)

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -91,17 +91,7 @@ export function broadcast(obj) {
         msg = encodeMessage(JSON.stringify(obj, replacer))
     }
 
-/*     if (obj.type === 'gamestate') {
-        stateCount++
-    }
-    if (obj.type === 'gamestate' && obj.payload.newFlames && obj.payload.newFlames.size > 1) {
-        console.log(reduceState(obj).payload.newFlames)
-        const sizeInKB = Buffer.byteLength(msg) / 1024
-        console.log(`Message size: ${sizeInKB.toFixed(2)} KB`)
-    } */
-
     const deadSockets = []
-    
     for (const socket of clients.keys()) {
         try {
             if (!socket.destroyed && socket.writable) {


### PR DESCRIPTION
I tried runnig the game at home, one computer as server and two playing. Game stuttered a bit every now and then and I wondered if reducing communincated data might help. Avg. game state size went from 0.7kB to 0.3kb, peak data (a lot of flames) went from 5kB to half of it. Also sending it now every 15ms instead of 10ms. Might not make a difference, but at least we can say we tried. I don't think anything broke.

Idea is not to send any empty arrays/maps and only send necessary properties of flames and players.